### PR TITLE
Make rtl2mqtt exit if rtl433 exits

### DIFF
--- a/src/rtl2mqtt.py
+++ b/src/rtl2mqtt.py
@@ -56,7 +56,11 @@ rtl433_proc = subprocess.Popen(rtl_433_cmd.split(),stdout=subprocess.PIPE,stderr
 
 
 while True:
+    if rtl433_proc.poll() is not None:
+        sys.exit(rtl433_proc.poll())
     for line in iter(rtl433_proc.stdout.readline, '\n'):
+        if rtl433_proc.poll() is not None:
+            sys.exit(rtl433_proc.poll())
         if "time" in line:
             mqttc.publish(MQTT_TOPIC, payload=line,qos=MQTT_QOS)
             json_dict = json.loads(line)


### PR DESCRIPTION
Force the internal loop to exit if rtl433 crashes. This will let systemd restart the entire fix the process and be pseudo-self-healing.