### PR TITLE
Additional output

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -12,7 +12,7 @@
 #
 # docker run --name rtl_433 -d -e MQTT_HOST=<mqtt-broker.example.com>   --privileged -v /dev/bus/usb:/dev/bus/usb  <image>
 
-FROM python:3.6.3
+FROM python:3.7
 MAINTAINER Marco Verleun
 
 LABEL Description="This image is used to start a script that will monitor for events on 433,92 Mhz" Vendor="MarCoach" Version="1.0"

--- a/src/config.py.example
+++ b/src/config.py.example
@@ -1,9 +1,10 @@
 # Config section
-# Uncomment these lines if your MQTT server requires authentication
-#MQTT_USER="mqtt-user"
-#MQTT_PASS="mqtt-password"
+# Fill in the next 2 lines if your MQTT server expected authentication
+MQTT_USER=""
+MQTT_PASS=""
 MQTT_HOST="mqtt.example.com"
 MQTT_PORT=1883
 MQTT_TOPIC="sensors/rtl_433"
 MQTT_QOS=0
+DEBUG=False # Change to True to log all MQTT messages
 # End config section

--- a/src/rtl2mqtt.py
+++ b/src/rtl2mqtt.py
@@ -14,7 +14,15 @@ rtl_433_cmd = "/usr/local/bin/rtl_433 -G -F json" # linux
 
 # Define MQTT event callbacks
 def on_connect(client, userdata, flags, rc):
-    print("Connected with result code "+str(rc))
+    connect_statuses = {
+        0: "Connected",
+        1: "incorrect protocol version",
+        2: "invalid client ID",
+        3: "server unavailable",
+        4: "bad username or password",
+        5: "not authorised"
+    }
+    print(connect_statuses.get(rc, "Unknown error"))
 
 def on_disconnect(client, userdata, rc):
     if rc != 0:


### PR DESCRIPTION
I had a few issues when getting RTL433-to-mqtt up and running:
* I couldn't get `docker build` to work out of the box
* MQTT auth wasn't working but I didn't know why

To try and help other avoid these snags, this PR:
1. Changes the Docker base image to the Python 3.7 version, which is a drop in to fix compilation of RTL433
2. Make the container print a more descriptive message to help debug the MQTT connection
3. Print the exit code of RTL433 to help work out issues at that step too
4. Made the auth a logging configurable from `config.py` instead of by editing the script, hopefully a step towards being able to share this image on Docker Hub

I hope this helps, and thank you for making & sharing such a useful tool!